### PR TITLE
Remove duplicate `old/bin/` from xt/01.2-deps.t

### DIFF
--- a/xt/01.2-deps.t
+++ b/xt/01.2-deps.t
@@ -36,7 +36,7 @@ sub collect {
     my $module = $File::Find::name;
     push @on_disk, $module
 }
-find(\&collect, 'lib/', 'old/bin/', 'old/lib/', 'old/bin/');
+find(\&collect, 'lib/', 'old/bin/', 'old/lib/');
 
 push @on_disk, 'tools/starman.psgi';
 


### PR DESCRIPTION
This was inadvertently introduced by myself in [commit eb5fbce](https://github.com/sbts/LedgerSMB/commit/eb5fbcea0dd1bff8e217a49b126de90d7ce1fbf3#diff-fff37642c4a6a0bafa93fc4dc0f848b1)